### PR TITLE
Remove netlight lock/unlock buttons

### DIFF
--- a/src/components/netlightPage.js
+++ b/src/components/netlightPage.js
@@ -38,14 +38,14 @@ const NetlightPage = () => {
         <GridItem>
           <img className={style.logo} src={netlight} alt="Netlight logo" />
 
-          {/*
+          {
             <p className={textClass}>
               Det går för tillfället inte att låsa/låsa upp Netlight genom denna
-              sida, då sektionsrummet är utlånat till D-group nu under
-              DÖMD-perioden.
+              sida, då sektionsrummet är utlånat till STABEN nu under
+              Nolle-P.
             </p>
-          */}
-          <p className={textClass}>{text}</p>
+          }
+          {/*<p className={textClass}>{text}</p>
           <div className={style.buttons}>
             <IconButton
               iconComponent={FiLock}
@@ -63,6 +63,7 @@ const NetlightPage = () => {
               style={{ margin: 0, marginTop: '1rem' }}
             >{`Batterinivå: ${Math.round(lockStatus.battery_percentage)}%`}</p>
           )}
+          */}
         </GridItem>
       </GridContainer>
     </BigPixels>


### PR DESCRIPTION
STABEN har ""bokat"" rummet under mottagningen. Det är inte en så bra lösning att endast plocka bort knapparna, men bör vara tillräckligt för att folk inte ska vandra in hursomhelst.