### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Nice to have as it helps provide consistency in the code style and is supported by many editors. Indent size is set to 2 as it seems to be used throughout the whole project.

Although VSC is likely smart enough to detect some properties like indent-size by itself, there's a plugin to add support for editorconfig. https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig