### PR TITLE
Limit fetching of bookings to the last 4 weeks and forwards

### DIFF
--- a/src/components/booking/itemPanel.js
+++ b/src/components/booking/itemPanel.js
@@ -9,7 +9,7 @@ import BookingCalendar from './bookingCalendar'
 import Pattern from '../ui/pattern'
 import ImageHeader from '../ui/imageHeader'
 
-const ItemPanel = ({ item, bookings, createBooking }) => {
+const ItemPanel = ({ item, bookings, createBooking, loadAllBookings }) => {
   const [openModal] = useModal(EditBooking)
 
   return (
@@ -33,11 +33,16 @@ const ItemPanel = ({ item, bookings, createBooking }) => {
           {'.'}
         </p>
       )}
-      <Button
-        onClick={() => openModal(`Boka ${item.name}`, { item, createBooking })}
-      >
-        {`Boka ${item.name}`}
-      </Button>
+      <div className={style.bookingButtonContainer}>
+        <Button
+          onClick={() =>
+            openModal(`Boka ${item.name}`, { item, createBooking })
+          }
+        >
+          {`Boka ${item.name}`}
+        </Button>
+        <Button onClick={loadAllBookings}>Ladda in äldre bokningar</Button>
+      </div>
     </div>
   )
 }

--- a/src/components/ui/titleChooser.js
+++ b/src/components/ui/titleChooser.js
@@ -13,6 +13,7 @@ const TitleChooser = ({
   action,
   actionLabel,
   noChoicesLabel,
+  onChange,
 }) => {
   const allChoices = [
     ...(choices || []),
@@ -39,6 +40,7 @@ const TitleChooser = ({
                     ? null
                     : allChoices.filter(i => `${i.id}` === selectedValue)[0]
                 setChoice(c)
+                onChange(e)
               }}
               value={choice ? choice.id : ''}
             >
@@ -82,6 +84,7 @@ TitleChooser.defaultProps = {
   noChoicesLabel: '',
   setChoice: () => {},
   label: '',
+  onChange: () => {},
 }
 
 TitleChooser.propTypes = {
@@ -94,6 +97,7 @@ TitleChooser.propTypes = {
   action: PropTypes.func,
   actionLabel: PropTypes.string,
   noChoicesLabel: PropTypes.string,
+  onChange: PropTypes.func,
 }
 
 export default TitleChooser

--- a/src/scss/booking.module.scss
+++ b/src/scss/booking.module.scss
@@ -39,3 +39,9 @@
     font-size: 1.25rem;
   }
 }
+
+.bookingButtonContainer {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}


### PR DESCRIPTION
**Changes:**
- Adds a limit to only fetch bookings starting from 4 weeks ago and forwards.
- Adds a button to the booking page to fetch all bookings.
- Adds an onChange callback to titleChooser component that is triggerd on change (wow!)

**Notes:**
Not a perfect solution imo. Optimally we should look into rewriting parts of the booking components with pagination in mind. With that said this will buy us some time.

Depends on d-sektionen/backend#24