### PR TITLE
Re-select the previously chosen selection in "D-Cide" and "Bokning"

### DIFF
--- a/src/components/ui/titleChooser.js
+++ b/src/components/ui/titleChooser.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import {actions, titleChooser, selectContainer, hint} from '../../scss/ui.module.scss'
 import { Button } from './buttons'
@@ -26,6 +26,18 @@ const TitleChooser = ({
       []
     ),
   ]
+
+  // Re-select the previously selected choice if there is one
+  useEffect(() => {
+    const savedChoice = sessionStorage.getItem(`${title}-selectedItem`)
+    if (savedChoice) {
+      const selectedItem = allChoices.find((item) => `${item.id}` === savedChoice)
+      if (selectedItem) {
+        setChoice(selectedItem)
+      }
+    }
+  }, [choices, categorizedChoices])
+
   return (
     <div className={titleChooser}>
       <h1>{title}</h1>
@@ -35,12 +47,19 @@ const TitleChooser = ({
             <select
               onChange={e => {
                 const selectedValue = e.target.value
-                const c =
+                const selectedItem =
                   selectedValue === ''
                     ? null
                     : allChoices.filter(i => `${i.id}` === selectedValue)[0]
-                setChoice(c)
+                setChoice(selectedItem)
                 onChange(e)
+
+                // Save the selected item for refresh re-select
+                if (selectedItem) {
+                  sessionStorage.setItem(`${title}-selectedItem`, selectedItem.id)
+                } else {
+                  sessionStorage.removeItem(`${title}-selectedItem`)
+                }
               }}
               value={choice ? choice.id : ''}
             >

--- a/src/components/ui/titleChooser.js
+++ b/src/components/ui/titleChooser.js
@@ -30,12 +30,15 @@ const TitleChooser = ({
   // Re-select the previously selected choice if there is one
   useEffect(() => {
     const savedChoice = sessionStorage.getItem(`${title}-selectedItem`)
-    if (savedChoice) {
-      const selectedItem = allChoices.find((item) => `${item.id}` === savedChoice)
-      if (selectedItem) {
-        setChoice(selectedItem)
-      }
+    if (!savedChoice) {
+      return;
     }
+
+    const selectedItem = allChoices.find((item) => `${item.id}` === savedChoice)
+    if (selectedItem) {
+      setChoice(selectedItem)
+    }
+
   }, [choices, categorizedChoices])
 
   return (


### PR DESCRIPTION
Added a feature that saves an item selection in the session storage of your browser, in order to keep the same choice in drop-down menu on refresh.

Intended effect is when a choice is made in a drop-down on either the "D-Cide" page or the "Bokning" page, we want to keep the selected choice upon refresh (F5). If the selected choice has been removed between refreshes then it should not select that, as it can't select a choice that is not present among choices.