### PR TITLE
Fixade event listeners på blippsystemet sidan

### DIFF
--- a/src/components/checkin/textField.js
+++ b/src/components/checkin/textField.js
@@ -30,7 +30,7 @@ const useTextField = (onEnter, elem) => {
       elem.current.addEventListener('keydown', downHandler)
       // Remove event listeners on cleanup
       return () => {
-        if (!elem.current) return;
+        if (!elem?.current) return;
         elem.current.removeEventListener('keydown', downHandler)
       }
     }


### PR DESCRIPTION
La till en return statement för att göra en early return om inte elementet längre finns.

En event listener som är på ett element som tas bort tas bort av garbage collectorn. Behöver inte göras manuellt. 