### PR TITLE
Felhantering och felmeddelande vid misslyckat försök att lägga till person i möte

### DIFF
--- a/src/components/votingAdmin/attendantPanel.js
+++ b/src/components/votingAdmin/attendantPanel.js
@@ -21,13 +21,38 @@ function AttendantCreationErrorLabel() {
     Det gick inte att lägga till användaren till mötet.
   </p>
   );
-} 
+}
+
 
 const AttendantPanel = ({ currentMeeting }) => {
   const [input, setInput] = useState('')
   const [confirmModal] = useConfirmModal()
   const [ showAttendantErrorLabel, setShowAttendantErroLabel] = useState(false)
   const closeModal = useCloseModal()
+
+
+  async function handleFormSubmit(event) {
+    event.preventDefault()
+    setInput('')
+
+    let newAttendant
+
+    try {
+      newAttendant = await post('/voting/attendants/', {
+        user_username: input,
+        meeting_id: currentMeeting.id,
+        has_voting_rights: true,
+      })
+    }
+    catch (error) {
+      setShowAttendantErroLabel(true)
+    }
+
+    if (newAttendant) {
+      setShowAttendantErroLabel(false)
+      mutate([...attendants, newAttendant])
+    }
+  }
 
   const { data: attendants, mutate } = useSWR(
     () => `/voting/attendants/?meeting_id=${currentMeeting.id}`,
@@ -36,32 +61,12 @@ const AttendantPanel = ({ currentMeeting }) => {
 
   if (attendants === null) return <></>
 
+
   return (
     <div>
       <h2>Deltagare</h2>
       <form
-        onSubmit={async e => {
-          e.preventDefault()
-          setInput('')
-
-          let newAttendant
-          
-          try {
-            newAttendant = await post('/voting/attendants/', {
-              user_username: input,
-              meeting_id: currentMeeting.id,
-              has_voting_rights: true,
-            })
-          }
-          catch (error) {
-            setShowAttendantErroLabel(true)
-          }
-          
-          if (newAttendant) {
-            setShowAttendantErroLabel(false)
-            mutate([...attendants, newAttendant])
-          }
-        }}
+        onSubmit={handleFormSubmit}
         >
         <input
           value={input}


### PR DESCRIPTION
closes #90 

Relaterar till https://github.com/d-sektionen/backend/pull/94

Felhantering och felmeddelande vid misslyckat försök att lägga till person i möte. Tidigare gav detta unhandled error. La till en komponent AttendantCreationErrorLabel som informerar användaren att det inte gick att lägga till en användare i ett möte, oavsett anledning.